### PR TITLE
Add livereload delay option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Metalsmith(__dirname)
   .use(livereload({
     // defaults
     debug: false,  // print debug messages
+    delay: 0, // add a delay before reloading the browser
     script: '<script ...'  // livereload script to inject
   }))
   .build((err, files) => {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ let server;
 
 const defaults = {
   debug: false,
+  delay: 0,
   script: `<script>document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>')</script>`
 };
 
@@ -24,7 +25,7 @@ module.exports = function (options) {
 
   if (!server) {
     debug('Starting livereload server.');
-    server = livereload.createServer({ debug: options.debug });
+    server = livereload.createServer({ debug: options.debug, delay: options.delay });
   }
 
   return function (files, metalsmith, done) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/arve0/metalsmith-livereload#readme",
   "dependencies": {
-    "livereload": "^0.4.1"
+    "livereload": "^0.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-livereload",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "starts a livereload server and injects livereload script to html files",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-livereload",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "description": "starts a livereload server and injects livereload script to html files",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
From [napsc/node-livereload](https://github.com/napcs/node-livereload) 
> add a delay (in miliseconds) between when livereload detects a change to the filesystem and when it notifies the browser

* Updated livereload dependency from 0.4.1 to 0.6.2
* Bumped package version from 0.0.2 to 1.0.0